### PR TITLE
Adicionando as mudanças nas tabelas logradouro e endereco

### DIFF
--- a/src/main/resources/db/migration/V035__alteracao_column_logradouro_bairro_cidade_estado.sql
+++ b/src/main/resources/db/migration/V035__alteracao_column_logradouro_bairro_cidade_estado.sql
@@ -1,0 +1,17 @@
+
+ALTER TABLE logradouro DROP COLUMN gia;
+ALTER TABLE logradouro DROP COLUMN ddd;
+ALTER TABLE logradouro DROP COLUMN siafi;
+
+ALTER TABLE logradouro RENAME COLUMN bairro TO fk_bairro;
+ALTER TABLE logradouro ALTER COLUMN fk_bairro TYPE int4 USING fk_bairro::int4;;
+
+ALTER TABLE logradouro RENAME COLUMN localidade TO fk_cidade;
+ALTER TABLE logradouro ALTER COLUMN fk_cidade TYPE int4 USING fk_cidade::int4;;
+
+ALTER TABLE logradouro RENAME COLUMN uf TO fk_estado;
+ALTER TABLE logradouro ALTER COLUMN fk_estado TYPE int4 USING fk_estado::int4;;
+
+ALTER TABLE logradouro ADD CONSTRAINT logradouro_fk_bairro FOREIGN KEY (fk_bairro) REFERENCES bairro(id_bairro);
+ALTER TABLE logradouro ADD CONSTRAINT logradouro_fk_cidade FOREIGN KEY (fk_cidade) REFERENCES cidade(id_cidade);
+ALTER TABLE logradouro ADD CONSTRAINT logradouro_fk_estado FOREIGN KEY (fk_estado) REFERENCES estado(id_estado);

--- a/src/main/resources/db/migration/V036__adicionando_a_coluna_cepDesconhecido.sql
+++ b/src/main/resources/db/migration/V036__adicionando_a_coluna_cepDesconhecido.sql
@@ -1,0 +1,1 @@
+ALTER TABLE logradouro ADD cep_desconhecido bool NULL;

--- a/src/main/resources/db/migration/V037__alteracao_endereco_column_id_endereco_fk_pessoa_fk_logradouro_fk_tipo_local.sql
+++ b/src/main/resources/db/migration/V037__alteracao_endereco_column_id_endereco_fk_pessoa_fk_logradouro_fk_tipo_local.sql
@@ -1,0 +1,7 @@
+ALTER TABLE public.endereco ADD fk_tipo_local integer NULL;
+
+ALTER TABLE endereco
+    ADD CONSTRAINT endereco_fk_tipo_local FOREIGN KEY (fk_tipo_local) REFERENCES tipoLocal(id_tipo_local);
+
+ALTER TABLE endereco
+    ALTER COLUMN referencia TYPE varchar(255) USING referencia::varchar;


### PR DESCRIPTION
- Exclusão das colunas gia, ddd, siafi da coluna logradouro;
- Renomeando as colunas bairro, localidade e uf para fk_bairro, fk_cidade e fk_estado respectivamente;
- Alterando os tipos de dados das colunas fk_bairro, fk_cidade e fk_estado para int;
- Adicionando chave estrangeira na tabela logradouro
- Adicionando a coluna cep_desconhecido na tabela logradouro
- Adicionando a coluna fk_tipo_local na tabela endereco.
- Adicionando chave estrangeira fk_tipo_local  para tabela endereco.
- Alterando o tipo de dado de referencia de varchar(255) para varchar